### PR TITLE
Change the Thrift namespace/Scala package name

### DIFF
--- a/src/main/thrift/event.thrift
+++ b/src/main/thrift/event.thrift
@@ -1,4 +1,4 @@
-namespace scala storypackage.thrift
+namespace scala com.gu.storypackage.model.v1
 
 /* The event type describe the resource state ii*/
 enum EventType {


### PR DESCRIPTION
This changes the Thrift namespace (which is also the package of Scrooge-generated Scala classes) to be more consistent with other Guardian projects using Thrift.