### PR TITLE
Fix cross-build release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
     "com.twitter" %% "scrooge-core" % "3.17.0"
 )
 
-crossScalaVersions := Seq("2.10.4", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.7")
 
 // Publish settings
 
@@ -38,7 +38,9 @@ pomExtra := (
 
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-    releaseProcess := Seq[ReleaseStep](
+releaseCrossBuild := true
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,
     runClean,
@@ -46,7 +48,7 @@ licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.h
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    releaseStepTask(PgpKeys.publishSigned),
+    publishArtifacts,
     setNextVersion,
     commitNextVersion,
     releaseStepCommand("sonatypeReleaseAll"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.9


### PR DESCRIPTION
Getting sbt-release to work with cross-building is a delicate art.

Luckily I wasted hours doing it for the CAPI client earlier today, so I am now an expert.