### PR TITLE
Split and rename thrift file

### DIFF
--- a/src/main/thrift/story_package_article.thrift
+++ b/src/main/thrift/story_package_article.thrift
@@ -1,11 +1,5 @@
 namespace scala com.gu.storypackage.model.v1
 
-/* The event type describe the resource state ii*/
-enum EventType {
-    Update = 1,
-    Delete = 2
-}
-
 /* Describes the types of articles that we can have */
 
 enum ArticleType {
@@ -48,14 +42,3 @@ struct Article {
 
     15: optional bool showQuotedHeadline;
 }
-
-struct Event {
-
-    1: required EventType eventType;
-
-    2: required string packageId;
-
-    3: required list<Article> articles;
-
-}
-

--- a/src/main/thrift/story_package_event.thrift
+++ b/src/main/thrift/story_package_event.thrift
@@ -1,0 +1,20 @@
+namespace scala com.gu.storypackage.model.v1
+
+include "story_package_article.thrift"
+
+/* The event type describe the resource state */
+enum EventType {
+    Update = 1,
+    Delete = 2
+}
+
+struct Event {
+
+    1: required EventType eventType;
+
+    2: required string packageId;
+
+    3: required list<story_package_article.Article> articles;
+
+}
+


### PR DESCRIPTION
This is to avoid name clashes when the files are included in other
Thrift files, e.g.:

https://github.com/guardian/content-api-scala-client/blob/b8c750bace54987d7e93400289ac9580a4ac5813/models/src/main/thrift/content/v1.thrift#L1