### PR TITLE
Upgrade the typescript generation plugin.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")


### PR DESCRIPTION
It now publishes `.d.ts` files alongside the compiled `.js` files, rather than `.ts` and `.js` as it was initially set up.

This ensures the client project that consumes the NPM package doesn't get any compilation error coming from the generated library.