### PR TITLE
Bump sbt to 1.5.7; remove bintray dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,17 +52,17 @@ lazy val scalaClasses = (project in file("scala"))
   .settings(
     name := "story-packages-model",
     description := "Story package model",
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeThriftOutputFolder in Compile := sourceManaged.value,
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftOutputFolder := sourceManaged.value,
     libraryDependencies ++= Seq(
         "org.apache.thrift" % "libthrift" % "0.12.0",
         "com.twitter" %% "scrooge-core" % "21.3.0",
         "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
     ),
     // Include the Thrift file in the published jar
-    scroogePublishThrift in Compile := true,
-    scroogeThriftIncludeRoot in Compile := false,
-    excludeLintKeys in Global += scroogeThriftIncludeRoot
+    Compile / scroogePublishThrift := true,
+    Compile / scroogeThriftIncludeRoot := false,
+    Global / excludeLintKeys += scroogeThriftIncludeRoot
   )
 
 lazy val thrift = (project in file("thrift"))
@@ -72,9 +72,9 @@ lazy val thrift = (project in file("thrift"))
     name := "story-packages-model-thrift",
     description := "Story package model Thrift files",
     crossPaths := false,
-    publishArtifact in packageDoc := false,
-    publishArtifact in packageSrc := false,
-    unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
+    packageDoc / publishArtifact := false,
+    packageSrc / publishArtifact := false,
+    Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
   )
 
 lazy val typescriptClasses = (project in file("ts"))
@@ -89,6 +89,6 @@ lazy val typescriptClasses = (project in file("ts"))
     description := "Typescript library built from the story packages thrift definition",
 
     Compile / scroogeLanguages := Seq("typescript"),
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
     scroogeTypescriptPackageLicense := "Apache-2.0"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ val commonSettings = Seq(
       ),
 
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-
   publishTo := sonatypePublishTo.value,
   publishConfiguration := publishConfiguration.value.withOverwrite(true),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
@@ -57,11 +56,13 @@ lazy val scalaClasses = (project in file("scala"))
     scroogeThriftOutputFolder in Compile := sourceManaged.value,
     libraryDependencies ++= Seq(
         "org.apache.thrift" % "libthrift" % "0.12.0",
-        "com.twitter" %% "scrooge-core" % "20.4.1",
+        "com.twitter" %% "scrooge-core" % "21.3.0",
         "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
     ),
     // Include the Thrift file in the published jar
-    scroogePublishThrift in Compile := true
+    scroogePublishThrift in Compile := true,
+    scroogeThriftIncludeRoot in Compile := false,
+    excludeLintKeys in Global += scroogeThriftIncludeRoot
   )
 
 lazy val thrift = (project in file("thrift"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.3.0")
 
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")


### PR DESCRIPTION
## What does this change?

Bumps sbt to 1.5.7 to address log4j vulnerability concerns. Whilst we're here we need to remove bintray dependencies as bintray has been shut down.

In addition, this PR resolves warnings around multi-thrift compilation (cf. https://github.com/guardian/ophan/pull/3973).

## How to test

sbt compiles successfully. 