### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .idea
+.bsp/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Ensure you have an NPM account, part of the [@guardian](https://www.npmjs.com/or
 
 You'll also need a sonatype account to publish the library to Maven.
 
+### New!
+Beta releases from a WIP branch can be deployed to Maven & npm. To do this, start sbt with
+`sbt -DRELEASE_TYPE=beta`
+When you follow the remaining instructions, you'll see a couple of new prompts and version number formats. We leave it
+up to the developer to keep track of the versions you've released this way, but you should always update the next
+version to reflect the beta status of the code (i.e. don't just let it revert to -SNAPSHOT which it will want to do by
+default). This is particularly important for npmRelease which you have to manually supply with a version number. Just
+use the same version identifier as you released to Maven.
+
+If you don't wish to make a beta release, just start sbt as normal (without the -DRELEASE_TYPE parameter) and continue
+with the steps that follow.
+
 ```sbtshell
 release // will release the scala / thrift projects
 project typescriptClasses

--- a/build.sbt
+++ b/build.sbt
@@ -52,17 +52,17 @@ lazy val scalaClasses = (project in file("scala"))
   .settings(
     name := "story-packages-model",
     description := "Story package model",
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeThriftOutputFolder in Compile := sourceManaged.value,
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftOutputFolder := sourceManaged.value,
     libraryDependencies ++= Seq(
         "org.apache.thrift" % "libthrift" % "0.12.0",
         "com.twitter" %% "scrooge-core" % "21.3.0",
         "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
     ),
     // Include the Thrift file in the published jar
-    scroogePublishThrift in Compile := true,
-    scroogeThriftIncludeRoot in Compile := false,
-    excludeLintKeys in Global += scroogeThriftIncludeRoot
+    Compile / scroogePublishThrift := true,
+    Compile / scroogeThriftIncludeRoot := false,
+    Global / excludeLintKeys += scroogeThriftIncludeRoot
   )
 
 lazy val thrift = (project in file("thrift"))
@@ -72,9 +72,9 @@ lazy val thrift = (project in file("thrift"))
     name := "story-packages-model-thrift",
     description := "Story package model Thrift files",
     crossPaths := false,
-    publishArtifact in packageDoc := false,
-    publishArtifact in packageSrc := false,
-    unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
+    packageDoc / publishArtifact := false,
+    packageSrc / publishArtifact := false,
+    Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
   )
 
 lazy val typescriptClasses = (project in file("ts"))
@@ -89,6 +89,6 @@ lazy val typescriptClasses = (project in file("ts"))
     description := "Typescript library built from the story packages thrift definition",
 
     Compile / scroogeLanguages := Seq("typescript"),
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
     scroogeTypescriptPackageLicense := "Apache-2.0"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,14 @@ import sbtrelease._
 import ReleaseStateTransformations._
 
 val thriftVersion = "0.15.0"
-val scroogeVersion = "21.12.0"
+val scroogeVersion = "22.1.0"
 
-val candidateReleaseType = "candidate"
-val candidateReleaseSuffix = "-RC1"
+val betaReleaseType = "beta"
+val betaReleaseSuffix = "-beta.0"
 
 lazy val versionSettingsMaybe = {
   sys.props.get("RELEASE_TYPE").map {
-    case v if v == candidateReleaseType => candidateReleaseSuffix
+    case v if v == betaReleaseType => betaReleaseSuffix
   }.map { suffix =>
     releaseVersion := {
       ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
@@ -40,7 +40,7 @@ lazy val mavenSettings = Seq(
 
 lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
   val releaseType = sys.props.get("RELEASE_TYPE").map {
-    case v if v == candidateReleaseType => candidateReleaseType.toUpperCase
+    case v if v == betaReleaseType => betaReleaseType.toUpperCase
   }.getOrElse("PRODUCTION")
 
   SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
@@ -73,18 +73,18 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
   )
 
   /*
-  Release Candidate assemblies can be published to Sonatype and Maven.
+  Beta assemblies can be published to Sonatype and Maven.
 
-  To make this work, start SBT with the candidate RELEASE_TYPE variable set;
-    sbt -DRELEASE_TYPE=candidate
+  To make this work, start SBT with the beta RELEASE_TYPE variable set;
+    sbt -DRELEASE_TYPE=beta
 
   This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
 
-  In this mode, the version number will be presented as e.g. 1.2.3-RC1, but the git tagging and version-updating
+  In this mode, the version number will be presented as e.g. 1.2.3-beta.n, but the git tagging and version-updating
   steps are not triggered, so it's up to the developer to keep track of what was released and manipulate subsequent
   release and next versions appropriately.
   */
-  val candidateSteps: Seq[ReleaseStep] = Seq(
+  val betaSteps: Seq[ReleaseStep] = Seq(
     setReleaseVersion,
     releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
@@ -92,7 +92,7 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
   )
 
   commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
-    case Some(v) if v == candidateReleaseType => candidateSteps // this enables a release candidate build to sonatype and Maven
+    case Some(v) if v == betaReleaseType => betaSteps // this enables a release candidate build to sonatype and Maven
     case None => prodSteps  // our normal deploy route
   })
 
@@ -146,9 +146,19 @@ lazy val thrift = (project in file("thrift"))
     Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
   )
 
+lazy val npmBetaReleaseTagMaybe =
+  sys.props.get("RELEASE_TYPE").map {
+    case v if v == betaReleaseType =>
+      // Why hard-code "beta" instead of using the value of the variable? That's to ensure it's always presented as
+      // --tag beta to the npm release process provided by the ScroogeTypescriptGen plugin regardless of how we identify
+      // a beta release here
+      scroogeTypescriptPublishTag := "beta"
+  }.toSeq
+
 lazy val typescriptClasses = (project in file("ts"))
   .enablePlugins(ScroogeTypescriptGen)
   .settings(commonSettings)
+  .settings(npmBetaReleaseTagMaybe)
   .settings(
     publishArtifact := false,
     name := "story-packages-typescript",
@@ -156,7 +166,6 @@ lazy val typescriptClasses = (project in file("ts"))
     Compile / scroogeDefaultJavaNamespace := scroogeTypescriptNpmPackageName.value,
     Test / scroogeDefaultJavaNamespace := scroogeTypescriptNpmPackageName.value,
     description := "Typescript library built from the story packages thrift definition",
-
     Compile / scroogeLanguages := Seq("typescript"),
     Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
     scroogeTypescriptPackageLicense := "Apache-2.0"

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,35 @@
 import sbtrelease._
 import ReleaseStateTransformations._
 
+val thriftVersion = "0.15.0"
+val scroogeVersion = "21.12.0"
+
 val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.13.2",
-  crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.2"),
+  crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   releaseCrossBuild := true,
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/story-packages-model"),
       "scm:git:git@github.com:guardian/story-packages-model.git")),
 
   pomExtra := (
-      <url>https://github.com/guardian/story-packages-model</url>
-      <developers>
-          <developer>
-              <id>Reettaphant</id>
-              <name>Reetta Vaahtoranta</name>
-              <url>https://github.com/guardian</url>
-          </developer>
-      </developers>
-      ),
+    <url>https://github.com/guardian/story-packages-model</url>
+    <developers>
+      <developer>
+          <id>Reettaphant</id>
+          <name>Reetta Vaahtoranta</name>
+          <url>https://github.com/guardian</url>
+      </developer>
+      <developer>
+        <id>justinpinner</id>
+        <name>Justin Pinner</name>
+        <url>https://github.com/justinpinner</url>
+      </developer>
+    </developers>
+  ),
 
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-  publishTo := sonatypePublishTo.value,
+  publishTo := sonatypePublishToBundle.value,
   publishConfiguration := publishConfiguration.value.withOverwrite(true),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseProcess := Seq[ReleaseStep](
@@ -35,7 +43,8 @@ val commonSettings = Seq(
       publishArtifacts,
       setNextVersion,
       commitNextVersion,
-      releaseStepCommand("sonatypeRelease"),
+      releaseStepCommandAndRemaining("+publishSigned"),
+      releaseStepCommand("sonatypeBundleRelease"),
       pushChanges
   )
 )
@@ -55,8 +64,8 @@ lazy val scalaClasses = (project in file("scala"))
     Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
     Compile / scroogeThriftOutputFolder := sourceManaged.value,
     libraryDependencies ++= Seq(
-        "org.apache.thrift" % "libthrift" % "0.12.0",
-        "com.twitter" %% "scrooge-core" % "21.3.0",
+        "org.apache.thrift" % "libthrift" % thriftVersion,
+        "com.twitter" %% "scrooge-core" % scroogeVersion,
         "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
     ),
     // Include the Thrift file in the published jar

--- a/build.sbt
+++ b/build.sbt
@@ -65,9 +65,9 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
     commitReleaseVersion,
     tagRelease,
     publishArtifacts,
-    setNextVersion,
     releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion,
     commitNextVersion,
     pushChanges
   )

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ val commonSettings = Seq(
       ),
 
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-
   publishTo := sonatypePublishTo.value,
   publishConfiguration := publishConfiguration.value.withOverwrite(true),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
@@ -57,11 +56,13 @@ lazy val scalaClasses = (project in file("scala"))
     scroogeThriftOutputFolder in Compile := sourceManaged.value,
     libraryDependencies ++= Seq(
         "org.apache.thrift" % "libthrift" % "0.12.0",
-        "com.twitter" %% "scrooge-core" % "20.4.1",
+        "com.twitter" %% "scrooge-core" % "21.3.0",
         "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
     ),
     // Include the Thrift file in the published jar
-    scroogePublishThrift in Compile := true
+    scroogePublishThrift in Compile := true,
+    scroogeThriftIncludeRoot in Compile := false,
+    excludeLintKeys in Global += scroogeThriftIncludeRoot
   )
 
 lazy val thrift = (project in file("thrift"))

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,100 @@ import ReleaseStateTransformations._
 val thriftVersion = "0.15.0"
 val scroogeVersion = "21.12.0"
 
+val candidateReleaseType = "candidate"
+val candidateReleaseSuffix = "-RC1"
+
+lazy val versionSettingsMaybe = {
+  sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseSuffix
+  }.map { suffix =>
+    releaseVersion := {
+      ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
+    }
+  }.toSeq
+}
+
+lazy val mavenSettings = Seq(
+  pomExtra := (
+    <url>https://github.com/guardian/story-packages-model</url>
+    <developers>
+      <developer>
+        <id>Reettaphant</id>
+        <name>Reetta Vaahtoranta</name>
+        <url>https://github.com/guardian</url>
+      </developer>
+      <developer>
+        <id>justinpinner</id>
+        <name>Justin Pinner</name>
+        <url>https://github.com/justinpinner</url>
+      </developer>
+      </developers>
+    ),
+  licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+  publishTo := sonatypePublishToBundle.value,
+  publishConfiguration := publishConfiguration.value.withOverwrite(true)
+)
+
+lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
+  val releaseType = sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseType.toUpperCase
+  }.getOrElse("PRODUCTION")
+
+  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
+    case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
+    case _ => sys.error(s"Release aborted by user!")
+  }
+  // we haven't changed state, just pass it on if we haven't thrown an error from above
+  st
+})
+
+lazy val releaseProcessSteps: Seq[ReleaseStep] = {
+  val commonSteps: Seq[ReleaseStep] = Seq(
+    checkReleaseType,
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest
+  )
+
+  val prodSteps: Seq[ReleaseStep] = Seq(
+    setReleaseVersion,
+    commitReleaseVersion,
+    tagRelease,
+    publishArtifacts,
+    setNextVersion,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
+    commitNextVersion,
+    pushChanges
+  )
+
+  /*
+  Release Candidate assemblies can be published to Sonatype and Maven.
+
+  To make this work, start SBT with the candidate RELEASE_TYPE variable set;
+    sbt -DRELEASE_TYPE=candidate
+
+  This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
+
+  In this mode, the version number will be presented as e.g. 1.2.3-RC1, but the git tagging and version-updating
+  steps are not triggered, so it's up to the developer to keep track of what was released and manipulate subsequent
+  release and next versions appropriately.
+  */
+  val candidateSteps: Seq[ReleaseStep] = Seq(
+    setReleaseVersion,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion
+  )
+
+  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
+    case Some(v) if v == candidateReleaseType => candidateSteps // this enables a release candidate build to sonatype and Maven
+    case None => prodSteps  // our normal deploy route
+  })
+
+}
+
 val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.13.2",
@@ -11,49 +105,15 @@ val commonSettings = Seq(
   releaseCrossBuild := true,
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/story-packages-model"),
       "scm:git:git@github.com:guardian/story-packages-model.git")),
-
-  pomExtra := (
-    <url>https://github.com/guardian/story-packages-model</url>
-    <developers>
-      <developer>
-          <id>Reettaphant</id>
-          <name>Reetta Vaahtoranta</name>
-          <url>https://github.com/guardian</url>
-      </developer>
-      <developer>
-        <id>justinpinner</id>
-        <name>Justin Pinner</name>
-        <url>https://github.com/justinpinner</url>
-      </developer>
-    </developers>
-  ),
-
-  licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-  publishTo := sonatypePublishToBundle.value,
-  publishConfiguration := publishConfiguration.value.withOverwrite(true),
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  releaseProcess := Seq[ReleaseStep](
-      checkSnapshotDependencies,
-      inquireVersions,
-      runClean,
-      runTest,
-      setReleaseVersion,
-      commitReleaseVersion,
-      tagRelease,
-      publishArtifacts,
-      setNextVersion,
-      commitNextVersion,
-      releaseStepCommandAndRemaining("+publishSigned"),
-      releaseStepCommand("sonatypeBundleRelease"),
-      pushChanges
-  )
-)
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value
+) ++ mavenSettings ++ versionSettingsMaybe
 
 lazy val root = (project in file("."))
   .aggregate(thrift, scalaClasses)
   .settings(commonSettings)
   .settings(
-    publishArtifact := false
+    publishArtifact := false,
+    releaseProcess := releaseProcessSteps
   )
 
 lazy val scalaClasses = (project in file("scala"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.3.0")
 
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.3.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.12.0")
 
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
 
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.5")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.12.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
 
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "22.1.0")
 
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.6")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.0-beta.1"
+ThisBuild / version := "2.2.0-beta.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.0-SNAPSHOT"
+ThisBuild / version := "2.1.0-RC2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.0-RC2"
+ThisBuild / version := "2.2.0-beta.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.5-SNAPSHOT"
+ThisBuild / version := "2.1.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
This extends Freddie's https://github.com/guardian/story-packages-model/pull/16 to bump additional dependencies in line with other library builds around the CAPI estate.

The intention here is to enable the construction of release candidate builds to test upgraded versions of scrooge etc and use those release candidates in consumer applications to probe for breaking changes.

This branch was used to build and release
[story packages model 2.2.0-beta.1 for scala 2.12](https://repo1.maven.org/maven2/com/gu/story-packages-model_2.12/2.2.0-beta.1/)
[story packages model 2.2.0-beta.1 for scala 2.13](https://repo1.maven.org/maven2/com/gu/story-packages-model_2.13/2.2.0-beta.1/)
[story packages model thrift 2.2.0-beta.1](https://repo1.maven.org/maven2/com/gu/story-packages-model-thrift/2.2.0-beta.1/)
and
[@guardian/story-packages-model 2.2.0-beta.1 for typescript](https://www.npmjs.com/package/@guardian/story-packages-model/v/2.2.0-beta.1)

## How to test
Build, release (as non-final builds) and ingest wherever we can test it/those

## How can we measure success?
Ideally consumers will not have any significant problems - if they do we'll consider our options.

## Have we considered potential risks?

Clients will have to specifically ingest these RC versions, so nothing should break as a result.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
 

