### PR TITLE
GHA Release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,15 @@
-name: Release
-
+name: 'Publish Release'
 on:
-  workflow_dispatch:
-
-jobs:
   release:
+    types: [published]
+jobs:
+  sbt_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: guardian/actions-sbt-release@v3
+        with:
+            pgpSecret: ${{ secrets.PGP_SECRET }}
+            pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
+            sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+            sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+            isSnapshot: ${{ github.event.release.prerelease }}

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val snapshotReleaseType = "snapshot"
 val snapshotReleaseSuffix = "-SNAPSHOT"
 
 val betaReleaseType = "beta"
-val betaReleaseSuffix = "-BETA"
+val betaReleaseSuffix = "-beta.0"
 
 lazy val versionSettingsMaybe = {
   sys.props.get("RELEASE_TYPE").map {

--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,16 @@ import ReleaseStateTransformations._
 val thriftVersion = "0.15.0"
 val scroogeVersion = "22.1.0"
 
+val snapshotReleaseType = "snapshot"
+val snapshotReleaseSuffix = "-SNAPSHOT"
+
 val betaReleaseType = "beta"
-val betaReleaseSuffix = "-beta.0"
+val betaReleaseSuffix = "-BETA"
 
 lazy val versionSettingsMaybe = {
   sys.props.get("RELEASE_TYPE").map {
-    case v if v == betaReleaseType => betaReleaseSuffix
+    case v if v == snapshotReleaseType => snapshotReleaseSuffix
+    case _ => ""
   }.map { suffix =>
     releaseVersion := {
       ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
@@ -38,65 +42,21 @@ lazy val mavenSettings = Seq(
   publishConfiguration := publishConfiguration.value.withOverwrite(true)
 )
 
-lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
-  val releaseType = sys.props.get("RELEASE_TYPE").map {
-    case v if v == betaReleaseType => betaReleaseType.toUpperCase
-  }.getOrElse("PRODUCTION")
+lazy val commonReleaseProcess = Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  setReleaseVersion,
+  runClean,
+  runTest,
+  // For non cross-build projects, use releaseStepCommand("publishSigned")
+  releaseStepCommandAndRemaining("+publishSigned")
+)
 
-  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
-    case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
-    case _ => sys.error(s"Release aborted by user!")
-  }
-  // we haven't changed state, just pass it on if we haven't thrown an error from above
-  st
-})
+lazy val productionReleaseProcess = commonReleaseProcess ++ Seq[ReleaseStep](
+  releaseStepCommand("sonatypeBundleRelease")
+)
 
-lazy val releaseProcessSteps: Seq[ReleaseStep] = {
-  val commonSteps: Seq[ReleaseStep] = Seq(
-    checkReleaseType,
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    runTest
-  )
-
-  val prodSteps: Seq[ReleaseStep] = Seq(
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    publishArtifacts,
-    releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
-    setNextVersion,
-    commitNextVersion,
-    pushChanges
-  )
-
-  /*
-  Beta assemblies can be published to Sonatype and Maven.
-
-  To make this work, start SBT with the beta RELEASE_TYPE variable set;
-    sbt -DRELEASE_TYPE=beta
-
-  This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
-
-  In this mode, the version number will be presented as e.g. 1.2.3-beta.n, but the git tagging and version-updating
-  steps are not triggered, so it's up to the developer to keep track of what was released and manipulate subsequent
-  release and next versions appropriately.
-  */
-  val betaSteps: Seq[ReleaseStep] = Seq(
-    setReleaseVersion,
-    releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
-    setNextVersion
-  )
-
-  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
-    case Some(v) if v == betaReleaseType => betaSteps // this enables a release candidate build to sonatype and Maven
-    case None => prodSteps  // our normal deploy route
-  })
-
-}
+lazy val snapshotReleaseProcess = commonReleaseProcess
 
 val commonSettings = Seq(
   organization := "com.gu",
@@ -113,7 +73,12 @@ lazy val root = (project in file("."))
   .settings(commonSettings)
   .settings(
     publishArtifact := false,
-    releaseProcess := releaseProcessSteps
+    releaseProcess := {
+      sys.props.get("RELEASE_TYPE") match {
+        case Some("production") => productionReleaseProcess
+        case _ => snapshotReleaseProcess
+      }
+    }
   )
 
 lazy val scalaClasses = (project in file("scala"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "2.2.1-SNAPSHOT"


### PR DESCRIPTION
What does this change?
This updates the release process so that this library is published to Sonatype via Github actions.

- It updates release.yml
- Removes version.sbt
- Tweaks build.sbt to enable the release process

The release process is built on the guardian/actions-sbt-release action, which does some version housekeeping and then runs sbt release.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
